### PR TITLE
[CPIT-551] Improve secret logic

### DIFF
--- a/UsersManager/Helpers/Extensions.cs
+++ b/UsersManager/Helpers/Extensions.cs
@@ -21,8 +21,10 @@ public static class Extensions
         var jwtSettings = configuration.GetSection("JwtSettings");
         var projectId = jwtSettings.GetSection("ProjectId")?.Value;
         var secretManager = new SecretManagerConfigurationProvider(projectId);
+        var jwtSecretName = jwtSettings.GetSection("SecretName").Value;
+        
         var jwtSecurityKey = Environment.GetEnvironmentVariable("JWT_SECRET") ??
-                             secretManager.GetSecret("JWT_SECRET") ??
+                             secretManager.GetSecret(jwtSecretName ?? "JWT_SECRET") ??
                              jwtSettings.GetSection("securityKey").Value;
 
         services.AddAuthentication(opt =>

--- a/UsersManager/Helpers/Extensions.cs
+++ b/UsersManager/Helpers/Extensions.cs
@@ -18,8 +18,9 @@ public static class Extensions
         services.AddIdentity<ApplicationUser, ApplicationRole>()
             .AddEntityFrameworkStores<ApplicationDbContext>();
         
-        var secretManager = new SecretManagerConfigurationProvider();
         var jwtSettings = configuration.GetSection("JwtSettings");
+        var projectId = jwtSettings.GetSection("ProjectId")?.Value;
+        var secretManager = new SecretManagerConfigurationProvider(projectId);
         var jwtSecurityKey = Environment.GetEnvironmentVariable("JWT_SECRET") ??
                              secretManager.GetSecret("JWT_SECRET") ??
                              jwtSettings.GetSection("securityKey").Value;

--- a/UsersManager/Security/JwtHandler.cs
+++ b/UsersManager/Security/JwtHandler.cs
@@ -26,8 +26,10 @@ public class JwtHandler
     {
         var projectId = _jwtSettings.GetSection("ProjectId")?.Value;
         var secretManager = new SecretManagerConfigurationProvider(projectId);
+        var jwtSecretName = _jwtSettings.GetSection("SecretName").Value;
+        
         var key = Encoding.UTF8.GetBytes(Environment.GetEnvironmentVariable("JWT_SECRET") ??
-                                          secretManager.GetSecret("JWT_SECRET") ??
+                                          secretManager.GetSecret(jwtSecretName ?? "JWT_SECRET") ??
                                          _jwtSettings.GetSection("securityKey").Value);
         var secret = new SymmetricSecurityKey(key);
         return new SigningCredentials(secret, SecurityAlgorithms.HmacSha256);

--- a/UsersManager/Security/JwtHandler.cs
+++ b/UsersManager/Security/JwtHandler.cs
@@ -24,8 +24,8 @@ public class JwtHandler
 
     public SigningCredentials GetSigningCredentials()
     {
-        var secretManager = new SecretManagerConfigurationProvider();
-
+        var projectId = _jwtSettings.GetSection("ProjectId")?.Value;
+        var secretManager = new SecretManagerConfigurationProvider(projectId);
         var key = Encoding.UTF8.GetBytes(Environment.GetEnvironmentVariable("JWT_SECRET") ??
                                           secretManager.GetSecret("JWT_SECRET") ??
                                          _jwtSettings.GetSection("securityKey").Value);

--- a/UsersManager/Security/SecretManagerConfigurationProvider.cs
+++ b/UsersManager/Security/SecretManagerConfigurationProvider.cs
@@ -1,4 +1,5 @@
 ﻿using Google.Api.Gax;
+using Google.Api.Gax.ResourceNames;
 using Google.Cloud.SecretManager.V1;
 using Microsoft.Extensions.Configuration;
 
@@ -6,13 +7,21 @@ namespace UsersManager.Security;
 
 public class SecretManagerConfigurationProvider : ConfigurationProvider
 {
-    public SecretManagerConfigurationProvider()
+    public SecretManagerConfigurationProvider(string? projectId = null)
     {
         try
         {
             Client = SecretManagerServiceClient.Create();
-            var instance = Platform.Instance();
-            ProjectId = instance?.ProjectId;
+            var platform = Platform.Instance();
+            if (platform != null && platform.ProjectId != null)
+            {
+                ProjectId = platform.ProjectId;
+            }
+            else if (projectId != null)
+            {
+                ProjectName project = new ProjectName(projectId);
+                ProjectId = project.ProjectId;
+            }
         }
         catch (Exception e)
         {

--- a/UsersManager/Security/SecretManagerConfigurationProvider.cs
+++ b/UsersManager/Security/SecretManagerConfigurationProvider.cs
@@ -36,7 +36,7 @@ public class SecretManagerConfigurationProvider : ConfigurationProvider
     {
         if (ProjectId == null) return null;
         // Build the resource name.
-        var secretVersionName = new SecretVersionName(ProjectId, secretId, "1");
+        var secretVersionName = new SecretVersionName(ProjectId, secretId, "latest");
 
         try
         {

--- a/UsersManager/UsersManager.csproj
+++ b/UsersManager/UsersManager.csproj
@@ -10,7 +10,7 @@
         <Description>Manage users .Net library</Description>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Version>2.0.0</Version>
-        <PackageVersion>4.1.1</PackageVersion>
+        <PackageVersion>4.1.3</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Allow developers to set the property `ProjectId`
- Allow developers to name their JWT Secret name something else than JWT_Secret for cases with multiple oAuth clients
- New structure for JWT Settings in appsettings:

```
"JWTSettings": {
    "validIssuer": "iss",
    "expiryInMinutes": 0,
    "validAudience": "https://localhost:44426",
    "SecretName": "JWT_Secret_Name", // the security key for google oauth client
    "ProjectId": "gcp-project"
  }
```